### PR TITLE
Add missing scopes for `variable.function` and `message.error` (#43)

### DIFF
--- a/Agila Cobalt.tmTheme
+++ b/Agila Cobalt.tmTheme
@@ -181,7 +181,7 @@
       <key>name</key>
       <string>Function Call</string>
       <key>scope</key>
-      <string>meta.function-call</string>
+      <string>variable.function</string>
       <key>settings</key>
       <dict>
         <key>foreground</key>

--- a/Agila Dracula.tmTheme
+++ b/Agila Dracula.tmTheme
@@ -239,6 +239,32 @@
         </dict>
         <dict>
             <key>name</key>
+            <string>Function call</string>
+            <key>scope</key>
+            <string>variable.function, variable.annotation</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#8be9fd</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Function annotation</string>
+            <key>scope</key>
+            <string>punctuation.definition.annotation</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#ff79c6</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
             <string>Tag name</string>
             <key>scope</key>
             <string>entity.name.tag</string>

--- a/Agila Light Solarized.tmTheme
+++ b/Agila Light Solarized.tmTheme
@@ -222,6 +222,32 @@
 		</dict>
 		<dict>
 			<key>name</key>
+			<string>Function call</string>
+			<key>scope</key>
+			<string>variable.function, variable.annotation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#859900</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Function annotation</string>
+			<key>scope</key>
+			<string>punctuation.definition.annotation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#657b83</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
 			<string>Variable start</string>
 			<key>scope</key>
 			<string>punctuation.definition.variable</string>

--- a/Agila Monokai Extended.tmTheme
+++ b/Agila Monokai Extended.tmTheme
@@ -217,6 +217,32 @@
     </dict>
     <dict>
       <key>name</key>
+      <string>Function call</string>
+      <key>scope</key>
+      <string>variable.function, variable.annotation</string>
+      <key>settings</key>
+      <dict>
+        <key>fontStyle</key>
+        <string></string>
+        <key>foreground</key>
+        <string>#66d9ef</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Function annotation</string>
+      <key>scope</key>
+      <string>punctuation.definition.annotation</string>
+      <key>settings</key>
+      <dict>
+        <key>fontStyle</key>
+        <string></string>
+        <key>foreground</key>
+        <string>#f92672</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
       <string>Tag name</string>
       <key>scope</key>
       <string>entity.name.tag</string>
@@ -1803,6 +1829,32 @@
         <string></string>
         <key>foreground</key>
         <string>#66d9ef</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Make build: Filename</string>
+      <key>scope</key>
+      <string>entity.name.filename</string>
+      <key>settings</key>
+      <dict>
+        <key>fontStyle</key>
+        <string></string>
+        <key>foreground</key>
+        <string>#e6db74</string>
+      </dict>
+    </dict>
+    <dict>
+      <key>name</key>
+      <string>Make build: warnings and errors</string>
+      <key>scope</key>
+      <string>message.error</string>
+      <key>settings</key>
+      <dict>
+        <key>fontStyle</key>
+        <string></string>
+        <key>foreground</key>
+        <string>#F92672</string>
       </dict>
     </dict>
     <dict>

--- a/Agila Neon Monocyanide.tmTheme
+++ b/Agila Neon Monocyanide.tmTheme
@@ -241,6 +241,32 @@
         </dict>
         <dict>
             <key>name</key>
+            <string>Function call</string>
+            <key>scope</key>
+            <string>variable.function, variable.annotation</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string>bold</string>
+                <key>foreground</key>
+                <string>#66d9ef</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Function annotation</string>
+            <key>scope</key>
+            <string>punctuation.definition.annotation</string>
+            <key>settings</key>
+            <dict>
+                <key>fontStyle</key>
+                <string></string>
+                <key>foreground</key>
+                <string>#ff4083</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
             <string>Tag name</string>
             <key>scope</key>
             <string>entity.name.tag</string>


### PR DESCRIPTION
## Modifications

- For each color scheme (`.tmTheme`), I first check if `variable.function` has already been handled, as described in #43.
- If not, I add new scopes `variable.function, variable.annotation`, and set their color to be the same as `support.function`.  
  - Since most of the time, we simply want library functions and normal functions to have the same color.
- If the first point is true, I also add new scope `punctuation.definition.annotation`, and set its color to be the same as `keyword.operater` or `keyword.operater.arithmetic`.
- For **Agila Extended Monokai** only, I added scopes for Makefile build outputs, namely `entity.name.filename` and `message.error`.

## Results

![cobalt](https://user-images.githubusercontent.com/23246033/116225791-d53d0600-a784-11eb-968f-80206b4d61df.png)
![dracula](https://user-images.githubusercontent.com/23246033/116225814-da9a5080-a784-11eb-9ccb-23964420834b.png)
![light](https://user-images.githubusercontent.com/23246033/116225823-dcfcaa80-a784-11eb-93bb-6844eb5e3160.png)
![monokai](https://user-images.githubusercontent.com/23246033/116225841-e0903180-a784-11eb-9373-b303eb7962d6.png)
![neon](https://user-images.githubusercontent.com/23246033/116226112-2ea53500-a785-11eb-918b-d26f195e98f1.png)
